### PR TITLE
avoid the underlying JSON factory closing a file's output stream

### DIFF
--- a/core/src/main/java/com/opentable/logging/JsonLogEncoder.java
+++ b/core/src/main/java/com/opentable/logging/JsonLogEncoder.java
@@ -66,7 +66,8 @@ public class JsonLogEncoder extends EncoderBase<ILoggingEvent> {
         logLine.put("sequencenumber", LOG_SEQUENCE_NUMBER.incrementAndGet());
 
         synchronized (outputStream) {
-            mapper.writeValue(outputStream, logLine);
+            String line = mapper.writeValueAsString(logLine);
+            outputStream.write(line.getBytes());
             outputStream.write('\n');
         }
     }


### PR DESCRIPTION
I was having trouble using the JsonLogEncoder with a FileAppender; only one log message was being written per run of my program. After some digging, I found out that writeValue() can implicitly close the output stream. Using the mapper's mapping capabilities and letting the output stream handle the writing fixed the issue for me (and I didn't notice it creating any new problems with a ConsoleAppender).