### PR TITLE
Deprecate the Log class.

### DIFF
--- a/logging/src/main/java/com/opentable/logging/Log.java
+++ b/logging/src/main/java/com/opentable/logging/Log.java
@@ -20,7 +20,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 /**
  * Wraps a Log4j logger into a number of convenience methods such as varargs.
+ *
+ * @deprecated This code is leftover from the Ness codebase and probably
+ * shouldn't be adopted in new code, use SLF4J {@link Logger} instead.
  */
+@Deprecated
 public final class Log
 {
     private static final String LOG_NAME = Log.class.getName();


### PR DESCRIPTION
This was prompted because @space-pope spent a bunch of time converting his perfectly good SLF4J code to Log, presuming it was "the right thing to do", when in fact generally we'd encourage the opposite.

Thoughts? @benhardy @strykerd @jeremyschiff 