### PR TITLE
Codahale -> Dropwizard updates.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-logging-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0</version>
   </parent>
 
   <artifactId>otj-logging-core</artifactId>

--- a/jetty/pom.xml
+++ b/jetty/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0</version>
   </parent>
 
   <artifactId>otj-logging-jetty</artifactId>

--- a/jetty/pom.xml
+++ b/jetty/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-logging-jetty</artifactId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0</version>
   </parent>
 
   <artifactId>otj-logging-kafka</artifactId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-logging-kafka</artifactId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0</version>
   </parent>
 
   <artifactId>otj-logging</artifactId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-oss</artifactId>
-    <version>47</version>
+    <version>49</version>
   </parent>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,13 @@
     <connection>scm:git:git://github.com/opentable/otj-logging.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-logging.git</developerConnection>
     <url>http://github.com/opentable/otj-logging</url>
-    <tag>otj-logging-parent-1.9.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-logging-parent</artifactId>
   <name>otj-logging-parent</name>
-  <version>1.9.0</version>
+  <version>1.9.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Logging component parent</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,13 @@
     <connection>scm:git:git://github.com/opentable/otj-logging.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-logging.git</developerConnection>
     <url>http://github.com/opentable/otj-logging</url>
-    <tag>HEAD</tag>
+    <tag>otj-logging-parent-1.9.0</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-logging-parent</artifactId>
   <name>otj-logging-parent</name>
-  <version>1.8.1-SNAPSHOT</version>
+  <version>1.9.0</version>
   <packaging>pom</packaging>
   <description>Logging component parent</description>
 

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0</version>
   </parent>
 
   <artifactId>otj-logging-redis</artifactId>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-logging-parent</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-logging-redis</artifactId>


### PR DESCRIPTION
When updating Guava to a later version, we discovered that there were
now conflicting classes for various Codahale metrics libraries.  This
led us to discover that the project started out as one of Coda's
personal projects; it used class namespace `com.codahale.metrics`.  He
was working at Yammer at the time, and the project became sufficiently
important for them to change its packaging to be associated with Yammer.
When they did this, they _changed_ the class namespace to
`com.yammer.metrics`.  Later, the project became sufficiently valuable
to the community that they open-sourced it.  On doing this, though, they
*changed the class namespace _back_* to `com.codahale.metrics` despite
the fact that the artifact `groupId` changed yet again to
`io.dropwizard.metrics`.  (wtf!)  We want only the modern Dropwizard
artifacts.

[See more here.][1]

[1]: https://groups.google.com/d/msg/dropwizard-user/1usH7frpnZE/RSQUsOBFMsoJ