### PR TITLE
Introduce test case that our partitioning strategy distributes evenly

### DIFF
--- a/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
+++ b/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
@@ -34,7 +34,7 @@ import kafka.producer.ProducerConfig;
  */
 public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 {
-    private final ThreadLocal<byte[]> partitionShufflerKey = ThreadLocal.withInitial(() -> new byte[1]);
+    private final PartitionKeyGenerator keyGenerator = new PartitionKeyGenerator();
 
     private Producer<byte[], byte[]> producer;
     private Encoder<ILoggingEvent> encoder;
@@ -86,9 +86,7 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
             throw Throwables.propagate(e);
         }
 
-        final byte[] key = partitionShufflerKey.get();
-        key[0]++;
-        producer.send(new KeyedMessage<>(topic, key, out.toByteArray()));
+        producer.send(new KeyedMessage<>(topic, keyGenerator.next(), out.toByteArray()));
     }
 
     public Encoder<ILoggingEvent> getEncoder()

--- a/kafka/src/main/java/com/opentable/logging/PartitionKeyGenerator.java
+++ b/kafka/src/main/java/com/opentable/logging/PartitionKeyGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.logging;
+
+class PartitionKeyGenerator {
+    private final ThreadLocal<byte[]> partitionShufflerKey = ThreadLocal.withInitial(() -> new byte[8]);
+
+    byte[] next() {
+        final byte[] key = partitionShufflerKey.get();
+
+        // Increment the byte array as if it were a single number
+        // Saves allocating new byte[] on every call, just reuse it, one per thread
+        for (int i = key.length-1; i >= 0; i--) {
+            if (key[i]++ != Byte.MIN_VALUE) {
+                break;
+            }
+        }
+
+        return key;
+    }
+}

--- a/kafka/src/test/java/com/opentable/logging/PartitionSpreadTest.java
+++ b/kafka/src/test/java/com/opentable/logging/PartitionSpreadTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.logging;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Multiset;
+import com.google.common.collect.TreeMultiset;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class PartitionSpreadTest {
+
+    @Parameters
+    public static Object[][] params() {
+        return new Object[][] {
+                {2, 1600},
+                {3, 5120},
+                {4, 5123516},
+                {7, 23490459},
+        };
+    }
+
+    @Parameter(0)
+    public int partitions;
+
+    @Parameter(1)
+    public int messages;
+
+    @Test
+    public void testPartitionSpread() throws Exception {
+        Multiset<Integer> results = TreeMultiset.create();
+        Cluster c = Cluster.empty();
+        Partitioner p = new DefaultPartitioner();
+        PartitionKeyGenerator pkg = new PartitionKeyGenerator();
+
+        mockPartitions(c);
+
+        for (int i = 0; i < messages; i++) {
+            results.add(p.partition("test", null, pkg.next(), null, null, c));
+        }
+
+        int expected = messages / partitions;
+        double threshold = expected * 0.025;
+
+        for (Multiset.Entry<Integer> e : results.entrySet()) {
+            int offBy = Math.abs(e.getCount() - expected);
+            assertTrue("Partition " + e.getElement() + " had " + e.getCount() + " elements, expected " + expected + ", threshold is " + threshold,
+                    offBy < threshold);
+        }
+    }
+
+    // Cluster is final and can't be mocked.  So crack it open the hard way.
+    @SuppressWarnings("unchecked")
+    private void mockPartitions(Cluster c) throws Exception {
+        List<PartitionInfo> partitionInfo = Arrays.asList(new PartitionInfo[partitions]);
+        Field partitionsByTopic = Cluster.class.getDeclaredField("partitionsByTopic");
+        partitionsByTopic.setAccessible(true);
+        Map<Object, Object> m = (Map<Object, Object>) partitionsByTopic.get(c);
+        m.put("test", partitionInfo);
+    }
+}


### PR DESCRIPTION
(hint: it doesn't...)

Kafka's `DefaultPartitioner` uses Murmur2 which seems to exhibit poor spread over single byte arguments.