### PR TITLE
Minor Changes

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,0 +1,1 @@
+/.checkstyle

--- a/core/src/main/java/com/opentable/logging/CommonLogHolder.java
+++ b/core/src/main/java/com/opentable/logging/CommonLogHolder.java
@@ -100,6 +100,7 @@ public final class CommonLogHolder
         try {
             return Integer.parseInt(System.getenv("INSTANCE_NO"));
         } catch (final NumberFormatException e) {
+            LOG.warn("Could not parse INSTANCE_NO.", e);
             return null;
         }
     }

--- a/core/src/main/java/com/opentable/logging/JsonLogEncoder.java
+++ b/core/src/main/java/com/opentable/logging/JsonLogEncoder.java
@@ -51,6 +51,7 @@ public class JsonLogEncoder extends EncoderBase<ILoggingEvent> {
      * Create a JSON Log Encoder
      * Sets up a JSON encoder and configures it.
      */
+    @SuppressWarnings("deprecation")
     public JsonLogEncoder() {
         // TODO: This sucks - - won't get the mapper customizations.  Find a way to inject this.
         // Master configuration is in otj-jackson
@@ -102,15 +103,14 @@ public class JsonLogEncoder extends EncoderBase<ILoggingEvent> {
      * @return the byte array to append to the log
      */
     protected byte[] getLogMessage(final ObjectNode event) {
-        ByteArrayBuilder buf = new ByteArrayBuilder();
-        try {
+        try(ByteArrayBuilder buf = new ByteArrayBuilder()){
             mapper.writeValue(buf, event);
+            buf.append('\n');
+            return buf.toByteArray();
         } catch (IOException e) {
             addError("while serializing log event", e);
             return NADA;
         }
-        buf.append('\n');
-        return buf.toByteArray();
     }
 
     @Override

--- a/jetty/.gitignore
+++ b/jetty/.gitignore
@@ -1,0 +1,1 @@
+/.checkstyle

--- a/kafka/.gitignore
+++ b/kafka/.gitignore
@@ -1,0 +1,1 @@
+/.checkstyle

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -51,7 +51,7 @@
           </exclusion>
           <exclusion>
             <groupId>com.opentable.components</groupId>
-            <artifactId>otj-conservedheaders</artifactId>
+            <artifactId>otj-conservedheaders-core</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.opentable.components</groupId>

--- a/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
+++ b/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serializer;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
@@ -40,6 +41,8 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
     private String compressionCodec = "snappy";
     private String clientId;
     private int bufSize = 1024;
+    private Serializer<byte[]> keySerializer;
+    private Serializer<byte[]> valueSerializer;
 
     @Override
     public void start()
@@ -56,7 +59,9 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
         config.put("acks", "1");
         config.put("compression.type", compressionCodec);
         config.put("client.id", clientId);
-        producer = new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer());
+        keySerializer = new ByteArraySerializer();
+        valueSerializer = new ByteArraySerializer();
+        producer = new KafkaProducer<>(config, keySerializer, valueSerializer);
     }
 
     @Override
@@ -65,6 +70,8 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
         addInfo("About to close Kafka producer");
         super.stop();
         producer.close();
+        keySerializer.close();
+        valueSerializer.close();
         addInfo("Finished closing Kafka producer");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>165</version>
+    <version>173</version>
   </parent>
 
   <scm>


### PR DESCRIPTION
 - Log warning when value of INSTANCE_NO is not a parseable integer
(remove unused vatr warning)
 - Close ByteArrayBuilder after logging a message (remove resource not
closed warning)
 - Save key and value serielizers and close them when done (remove
resource not closed warning)
 - Use core version of conserved headers dependency
 - Use version 173 of parent pom