### PR TITLE
Allowing callers to override the loglov3 otl if they wish to do so

### DIFF
--- a/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
+++ b/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
@@ -99,7 +99,7 @@ class ApplicationLogEvent implements CommonLogFields
 
     @Override
     public String getLoglov3Otl() {
-        return event.getMDCPropertyMap().getOrDefault("@loglov3-otl", "msg-v1");
+        return event.getMDCPropertyMap().getOrDefault("@loglov3-otl-override", "msg-v1");
     }
 
     /**

--- a/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
+++ b/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
@@ -99,7 +99,7 @@ class ApplicationLogEvent implements CommonLogFields
 
     @Override
     public String getLoglov3Otl() {
-        return "msg-v1";
+        return event.getMDCPropertyMap().getOrDefault("@loglov3-otl", "msg-v1");
     }
 
     /**


### PR DESCRIPTION
In case a caller set an `@loglov3-otl` field through MDC, honor that, rather than silently changing the field to `msg-v1`.

Cf discussion on slack for more details https://opentable.slack.com/archives/CA61R6PAR/p1541450366051800