### PR TITLE
Per OTPL-4104, this commit changes the timestamp for logged events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-logging
 ===========
 
+3.0.6
+-----
+* In JsonRequestLog set the timestamp to be time the request was completed, not the time it arrived.
+
 3.0.5
 -----
 * Obey HeaderBlacklist in logging from MDC

--- a/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
+++ b/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
@@ -110,8 +110,7 @@ public class JsonRequestLog extends AbstractLifeCycle implements RequestLog
                 .logName("request")
                 .serviceType(CommonLogHolder.getServiceType())
                 .uuid(UUID.randomUUID())
-                .timestamp(Instant.ofEpochMilli(request.getTimeStamp()))
-
+                .timestamp(clock.instant())
                 .method(request.getMethod())
                 .status(response.getStatus())
                 .incoming(true)


### PR DESCRIPTION
in JsonRequestLog to be the time a the end of the request, not the
time at the start of the request.

One this is merged and a new release built, the updated version must be added to otj-parent and a new parent pom version generated.