### PR TITLE
Per OTPL-4371, I have long been irritated to see a backtrace parsing

### DIFF
--- a/core/src/main/java/com/opentable/logging/CommonLogHolder.java
+++ b/core/src/main/java/com/opentable/logging/CommonLogHolder.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 /**
  * Holds values common to most/all log messages
@@ -97,10 +98,15 @@ public final class CommonLogHolder
     }
 
     private static Integer getInstanceNumber() {
+        final String instanceNoString = System.getenv("INSTANCE_NO");
+        if (StringUtils.isEmpty(instanceNoString)) {
+            LOG.warn("Environment variable INSTANCE_NO was not supplied");
+            return null;
+        }
         try {
-            return Integer.parseInt(System.getenv("INSTANCE_NO"));
+            return Integer.parseInt(instanceNoString);
         } catch (final NumberFormatException e) {
-            LOG.warn("Could not parse INSTANCE_NO.", e);
+            LOG.warn("Could not parse INSTANCE_NO, whose value is '{}'", instanceNoString);
             return null;
         }
     }


### PR DESCRIPTION
a non-existent instance number in every test I run.  The commit prints
a sensible one-line warning if INSTANCE_NO is missing or malformed.