### PR TITLE
Most of what's needed to wire up k8s info in logging for requests.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,10 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.opentable.components</groupId>
+      <artifactId>otj-spring</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.opentable.logging</groupId>
       <artifactId>otj-otl</artifactId>

--- a/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
+++ b/core/src/main/java/com/opentable/logging/ApplicationLogEvent.java
@@ -102,6 +102,31 @@ class ApplicationLogEvent implements CommonLogFields
         return event.getMDCPropertyMap().getOrDefault("@loglov3-otl-override", "msg-v1");
     }
 
+    @Override
+    public String getClusterName() {
+        return CommonLogHolder.getK8sInfo().getClusterName();
+    }
+
+    @Override
+    public String getNamespace() {
+        return CommonLogHolder.getK8sInfo().getNameSpace();
+    }
+
+    @Override
+    public String getNodeHost() {
+        return CommonLogHolder.getK8sInfo().getNodeHost();
+    }
+
+    @Override
+    public String getPodName() {
+        return CommonLogHolder.getK8sInfo().getPodName();
+    }
+
+    @Override
+    public String getServiceName() {
+        return CommonLogHolder.getK8sInfo().getServiceName();
+    }
+
     /**
      * A converter that converts {@link IThrowableProxy} objects to Strings
      */

--- a/core/src/main/java/com/opentable/logging/CommonLogFields.java
+++ b/core/src/main/java/com/opentable/logging/CommonLogFields.java
@@ -171,4 +171,40 @@ public interface CommonLogFields
      */
     @JsonProperty("@loglov3-otl")
     String getLoglov3Otl();
+
+
+    /**
+     * Kubernetes cluster name
+     * @return the cluster name
+     */
+    @JsonProperty("k8s-cluster-name")
+    String getClusterName();
+
+    /**
+     * Kubernetes namespace
+     * @return the namespace
+     */
+    @JsonProperty("k8s-namespace")
+    String getNamespace();
+
+    /**
+     * Kubernetes Node Host
+     * @return the node host
+     */
+    @JsonProperty("k8s-node-host")
+    String getNodeHost();
+
+    /**
+     * Kubernetes Pod name
+     * @return the kubernetes pod name
+     */
+    @JsonProperty("k8s-pod-name")
+    String getPodName();
+
+    /**
+     * Kubernetes service name
+     * @return the kubernetes service name
+     */
+    @JsonProperty("k8s-service-name")
+    String getServiceName();
 }

--- a/core/src/main/java/com/opentable/logging/CommonLogHolder.java
+++ b/core/src/main/java/com/opentable/logging/CommonLogHolder.java
@@ -19,12 +19,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
-import com.opentable.service.K8sInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
+
+import com.opentable.service.K8sInfo;
 
 /**
  * Holds values common to most/all log messages
@@ -42,7 +42,7 @@ public final class CommonLogHolder
     static String OT_ENV, OT_ENV_TYPE, OT_ENV_LOCATION, OT_ENV_FLAVOR; //NOPMD
     private static String serviceType = UNSET; //NOPMD
 
-    private static final AtomicReference<K8sInfo> k8sInfo = new AtomicReference<>();
+    private static final AtomicReference<KubernetesLogHolder> k8sInfo = new AtomicReference<>();
 
     static {
         final String hostNameEnv = System.getenv("TASK_HOST");
@@ -92,11 +92,11 @@ public final class CommonLogHolder
         CommonLogHolder.serviceType = serviceType;
     }
     public static void setK8sInfo(K8sInfo k8sInfo) {
-        CommonLogHolder.k8sInfo.set(k8sInfo);
+        CommonLogHolder.k8sInfo.set(new KubernetesLogHolder(Optional.ofNullable(k8sInfo)));
     }
 
-    public static Optional<K8sInfo> getK8sInfo() {
-        return Optional.ofNullable(CommonLogHolder.k8sInfo.get());
+    public static KubernetesLogHolder getK8sInfo() {
+        return Optional.ofNullable(CommonLogHolder.k8sInfo.get()).orElse(KubernetesLogHolder.EMPTY);
     }
 
     /**

--- a/core/src/main/java/com/opentable/logging/CommonLogHolder.java
+++ b/core/src/main/java/com/opentable/logging/CommonLogHolder.java
@@ -16,8 +16,12 @@ package com.opentable.logging;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
+import com.opentable.service.K8sInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -37,6 +41,8 @@ public final class CommonLogHolder
     static final Integer INSTANCE_NO;
     static String OT_ENV, OT_ENV_TYPE, OT_ENV_LOCATION, OT_ENV_FLAVOR; //NOPMD
     private static String serviceType = UNSET; //NOPMD
+
+    private static final AtomicReference<K8sInfo> k8sInfo = new AtomicReference<>();
 
     static {
         final String hostNameEnv = System.getenv("TASK_HOST");
@@ -84,6 +90,13 @@ public final class CommonLogHolder
 
     public static void setServiceType(String serviceType) {
         CommonLogHolder.serviceType = serviceType;
+    }
+    public static void setK8sInfo(K8sInfo k8sInfo) {
+        CommonLogHolder.k8sInfo.set(k8sInfo);
+    }
+
+    public static Optional<K8sInfo> getK8sInfo() {
+        return Optional.ofNullable(CommonLogHolder.k8sInfo.get());
     }
 
     /**

--- a/core/src/main/java/com/opentable/logging/KubernetesLogHolder.java
+++ b/core/src/main/java/com/opentable/logging/KubernetesLogHolder.java
@@ -1,0 +1,34 @@
+package com.opentable.logging;
+
+import java.util.Optional;
+
+import com.opentable.service.K8sInfo;
+
+public class KubernetesLogHolder {
+    public static final KubernetesLogHolder EMPTY = new KubernetesLogHolder(Optional.empty());
+
+    private final K8sInfo k8sInfo;
+    public KubernetesLogHolder(Optional<K8sInfo> k8sInfo) {
+        this.k8sInfo = k8sInfo.orElse(new K8sInfo());
+    }
+
+    public String getClusterName() {
+        return k8sInfo.getClusterName().orElse(null);
+    }
+
+    public String getNameSpace() {
+        return k8sInfo.getNamespace().orElse(null);
+    }
+
+    public String getNodeHost() {
+        return k8sInfo.getNodeHost().orElse(null);
+    }
+
+    public String getPodName() {
+        return k8sInfo.getPodName().orElse(null);
+    }
+
+    public String getServiceName() {
+        return k8sInfo.getServiceName().orElse(null);
+    }
+}

--- a/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
+++ b/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
@@ -112,7 +112,9 @@ public class JsonRequestLog extends AbstractLifeCycle implements RequestLog
     @Nonnull
     protected HttpV1 createEvent(Request request, Response response) {
         final String query = request.getQueryString();
-        return HttpV1.builder()
+        HttpV1.HttpV1Builder builder = HttpV1.builder();
+        addKubernetesInfo(builder);
+        return builder
                 .logName("request")
                 .serviceType(CommonLogHolder.getServiceType())
                 .uuid(UUID.randomUUID())
@@ -155,6 +157,17 @@ public class JsonRequestLog extends AbstractLifeCycle implements RequestLog
                 .headerXForwardedProto(request.getHeader(HttpHeaders.X_FORWARDED_PROTO))
 
                 .build();
+    }
+
+    private void addKubernetesInfo(final HttpV1.HttpV1Builder builder) {
+        CommonLogHolder.getK8sInfo().ifPresent(k8sInfo -> {
+            builder
+                    .k8SClusterName(k8sInfo.getClusterName().orElse(null))
+                    .k8SNamespace(k8sInfo.getNamespace().orElse(null))
+                    .k8SNodeHost(k8sInfo.getNodeHost().orElse(null))
+                    .k8SPodName(k8sInfo.getPodName().orElse(null))
+                    .k8SServiceName(k8sInfo.getServiceName().orElse(null));
+        });
     }
 
     /**

--- a/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
+++ b/jetty/src/main/java/com/opentable/logging/jetty/JsonRequestLog.java
@@ -112,9 +112,7 @@ public class JsonRequestLog extends AbstractLifeCycle implements RequestLog
     @Nonnull
     protected HttpV1 createEvent(Request request, Response response) {
         final String query = request.getQueryString();
-        HttpV1.HttpV1Builder builder = HttpV1.builder();
-        addKubernetesInfo(builder);
-        return builder
+        return HttpV1.builder()
                 .logName("request")
                 .serviceType(CommonLogHolder.getServiceType())
                 .uuid(UUID.randomUUID())
@@ -157,17 +155,6 @@ public class JsonRequestLog extends AbstractLifeCycle implements RequestLog
                 .headerXForwardedProto(request.getHeader(HttpHeaders.X_FORWARDED_PROTO))
 
                 .build();
-    }
-
-    private void addKubernetesInfo(final HttpV1.HttpV1Builder builder) {
-        CommonLogHolder.getK8sInfo().ifPresent(k8sInfo -> {
-            builder
-                    .k8SClusterName(k8sInfo.getClusterName().orElse(null))
-                    .k8SNamespace(k8sInfo.getNamespace().orElse(null))
-                    .k8SNodeHost(k8sInfo.getNodeHost().orElse(null))
-                    .k8SPodName(k8sInfo.getPodName().orElse(null))
-                    .k8SServiceName(k8sInfo.getServiceName().orElse(null));
-        });
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>228</version>
+    <version>236</version>
   </parent>
 
   <scm>
@@ -44,10 +44,7 @@
   </modules>
 
   <properties>
-    <!-- remove once parent updated -->
-    <dep.otj-otl.version>0.9.11</dep.otj-otl.version>
-    <dep.otj-httpheaders.version>0.1.6</dep.otj-httpheaders.version>
-    <!-- end remove once parent updated -->
+   <dep.otj-spring.version>1.3.10</dep.otj-spring.version>
     <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
     <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
     <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>


### PR DESCRIPTION
Note that CommonLogHolder.setK8sInfo must be called somewhere because currently Logback integration is resolutely not spring compatible.

Can be called in ServiceLoggingConfiguration, where CommonLogHolder.setServiceType is also called.

@seif this is the first implementation unless you've beaten me to it?
@fessyfoo fyi