### PR TITLE
OTPL-5667 - AsyncAppender workaround.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-logging
 ===========
 
+5.2.3
+-----
+* Workaround for the AsyncAppenderBase#Worker thread race condition (see https://jira.qos.ch/browse/LOGBACK-1548)
+
 5.2.2
 -----
 * Rename the configuration @Values for blacklist => blocklist

--- a/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
+++ b/kafka/src/main/java/com/opentable/logging/KafkaAppender.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -70,6 +71,9 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
     {
         addInfo("About to close Kafka producer");
         super.stop();
+        if (Thread.interrupted()) {
+            addWarn("KafkaAppender::stop() is called from the interrupted thread, we cleared interrupt flag.");
+        }
         producer.close();
         keySerializer.close();
         valueSerializer.close();
@@ -79,7 +83,16 @@ public class KafkaAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
     @Override
     protected void append(ILoggingEvent eventObject)
     {
-        producer.send(new ProducerRecord<>(topic, keyGenerator.next(), encoder.encode(eventObject)));
+        try {
+            producer.send(new ProducerRecord<>(topic, keyGenerator.next(), encoder.encode(eventObject)));
+        } catch (InterruptException e) {
+            if (Thread.interrupted()) {
+                addWarn("KafkaAppender::append() is called from the interrupted thread, we cleared interrupt flag and about to retry..");
+                producer.send(new ProducerRecord<>(topic, keyGenerator.next(), encoder.encode(eventObject)));
+            } else {
+                throw e;
+            }
+        }
     }
 
     public Encoder<ILoggingEvent> getEncoder()


### PR DESCRIPTION
The AsyncAppender has race condition when it may not clear interrupt flag of the thread. https://github.com/qos-ch/logback/blob/master/logback-core/src/main/java/ch/qos/logback/core/AsyncAppenderBase.java#L289 and than trying to flush queue. This adds workaround for this.